### PR TITLE
added return NULL for missing mandatory fields

### DIFF
--- a/src/bootinfo.c
+++ b/src/bootinfo.c
@@ -466,7 +466,7 @@ struct Service * cJSON_GetServiceValue(const cJSON * j) {
                 }
             }
             else {
-                x->configuration = list_create(false, NULL);
+                return NULL; // If no configuration is provided, return NULL
             }
             if (cJSON_HasObjectItem(j, "inputs")) {
                 list_t * x1 = list_create(false, NULL);
@@ -480,10 +480,13 @@ struct Service * cJSON_GetServiceValue(const cJSON * j) {
                 }
             }
             else {
-                x->inputs = list_create(false, NULL);
+                return NULL; // If no inputs are provided, return NULL
             }
             if (cJSON_HasObjectItem(j, "name")) {
                 x->name = strdup(cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(j, "name")));
+            }
+            else {
+                return NULL; // If no name is provided, return NULL
             }
             if (cJSON_HasObjectItem(j, "outputs")) {
                 list_t * x1 = list_create(false, NULL);
@@ -497,19 +500,19 @@ struct Service * cJSON_GetServiceValue(const cJSON * j) {
                 }
             }
             else {
-                x->outputs = list_create(false, NULL);
+                return NULL; // If no outputs are provided, return NULL
             }
             if (cJSON_HasObjectItem(j, "tuning")) {
                 x->tuning = cJSON_GetTuningValue(cJSON_GetObjectItemCaseSensitive(j, "tuning"));
             }
+            else {
+                return NULL; // If no tuning is provided, return NULL
+            }
             if (cJSON_HasObjectItem(j, "version")) {
                 x->version = strdup(cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(j, "version")));
             }
-            if (cJSON_HasObjectItem(j, "service")) {
-                x->service = (void *)0xDEADBEEF;
-            }
             else {
-                x->service = (void *)0xDEADBEEF;
+                return NULL; // If no version is provided, return NULL
             }
         }
     }


### PR DESCRIPTION
If the mandatory fields in the bootspec schema are missing, we returned a null list. However, that has been changed to return NULL and crash the program. That is the functionality we need